### PR TITLE
fix: ingress

### DIFF
--- a/chart/pyroscope/Chart.yaml
+++ b/chart/pyroscope/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pyroscope
 description: A Helm chart for Pyroscope
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.0.34"

--- a/chart/pyroscope/README.md
+++ b/chart/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.34](https://img.shields.io/badge/AppVersion-0.0.34-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.34](https://img.shields.io/badge/AppVersion-0.0.34-informational?style=flat-square)
 
 A Helm chart for Pyroscope
 
@@ -44,6 +44,7 @@ helm delete my-release
 | image.tag | string | `"0.0.34"` | Tag for pyroscope image to use |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | ingress.annotations | object | `{}` | Ingress annotations (values are templated) |
+| ingress.apiVersion | string | `"networking.k8s.io/v1"` | Ingress API version: networking.k8s.io/v1 (Kubernetes v1.19+) or networking.k8s.io/v1beta1 |
 | ingress.enabled | bool | `false` | Enables Ingress |
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress accepted hostnames |
 | ingress.tls | list | `[]` | Ingress TLS configuration |

--- a/chart/pyroscope/templates/ingress.yaml
+++ b/chart/pyroscope/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "pyroscope.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
-apiVersion: networking.k8s.io/v1
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-apiVersion: networking.k8s.io/v1beta1
-  {{- end }}
+apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,11 +29,11 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if .pathType }}
+            {{- if and (eq $.Values.ingress.apiVersion "networking.k8s.io/v1") .pathType }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if eq $.Values.ingress.apiVersion "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/chart/pyroscope/values.yaml
+++ b/chart/pyroscope/values.yaml
@@ -125,6 +125,8 @@ service:
 ingress:
   # -- Enables Ingress
   enabled: false
+  # -- Ingress API version: networking.k8s.io/v1 (Kubernetes v1.19+) or networking.k8s.io/v1beta1
+  apiVersion: networking.k8s.io/v1
   # -- Ingress annotations (values are templated)
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
the ingress template was not compatible with kubernetes < 1.19, because instead of checking for `networking.k8s.io/v1` it should have check for `networking.k8s.io/v1/Ingress`

I changed it to be a manual configuration, defaulting to v1 (kube 1.19+) to keep the same "default" (because v1beta1 was never selected...)