### PR TITLE
initial implementation of volume perm setup via initContainer

### DIFF
--- a/chart/pyroscope/templates/deployment.yaml
+++ b/chart/pyroscope/templates/deployment.yaml
@@ -27,6 +27,20 @@ spec:
       serviceAccountName: {{ include "pyroscope.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{ if .Values.persistence.enabled }}
+      - name: volume-perms
+        image: {{ .Values.volumePerms.image }}
+        command:
+        - sh
+        - -c
+        - chown -R "{{ .Values.volumePerms.user }}:{{ .Values.volumePerms.group }}" {{ index .Values.pyroscopeConfigs "storage-path" | default "/var/lib/pyroscope" }}
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: storage
+            mountPath: {{ index .Values.pyroscopeConfigs "storage-path" | default "/var/lib/pyroscope" }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           args:

--- a/chart/pyroscope/values.yaml
+++ b/chart/pyroscope/values.yaml
@@ -92,6 +92,11 @@ persistence:
   # selectorLabels: {}
   # existingClaim:
 
+volumePerms:
+  image: busybox:latest
+  user: 100
+  group: 101
+
 # -- Pod annotations
 podAnnotations: {}
 


### PR DESCRIPTION
Inspired by @kolesnikovae's idea in https://github.com/pyroscope-io/helm-chart/issues/13#issuecomment-915899056 I tried to see what it would take to run the volume setup stuff in`initContainer`

This is by no any means prod ready, so I will leave as a draft for now.
But it's a good starting point for when we really tackle the problem.