### PR TITLE
Pyroscope configuration options

### DIFF
--- a/chart/pyroscope/Chart.yaml
+++ b/chart/pyroscope/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pyroscope
 description: A Helm chart for Pyroscope
 type: application
-version: 0.2.6
-appVersion: "0.0.34"
+version: 0.2.7
+appVersion: "0.0.37"

--- a/chart/pyroscope/README.md
+++ b/chart/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.34](https://img.shields.io/badge/AppVersion-0.0.34-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.37](https://img.shields.io/badge/AppVersion-0.0.37-informational?style=flat-square)
 
 A Helm chart for Pyroscope
 
@@ -34,7 +34,8 @@ helm delete my-release
 
 ## Persistence
 
-If you enable persistence, you should also configure the pod's security context `fsGroup`, to be able to write to the persistent volume. Set it to the group ID of the user running Pyroscope - `101` in the official Pyroscope container image.
+If you enable persistence, you should also configure the pod's security context `fsGroup`, to be able to write to the persistent volume.
+The official Pyroscope container image runs pyroscope server process with user ID `101`, setting `fsGroup` to this value should be sufficient in most cases:
 
 ```yaml
 persistence:
@@ -42,6 +43,14 @@ persistence:
 podSecurityContext:
   fsGroup: 101
 ```
+
+This includes all processes of the container to the supplemental group and makes kubelet to change the ownership of mounted volumes to this group (recursively; setgid bit is set).
+The only requirement for `fsGroup` is that it should be within the allowed range (e.g. defined by `SecurityContextConstraints`).
+
+## Pyroscope configuration
+
+`pyroscopeConfigs` parameter may include any supported pyroscope server configuration option.
+Please refer to [the documentation](https://pyroscope.io/docs/server-configuration) for details.
 
 ## Values
 
@@ -55,7 +64,7 @@ podSecurityContext:
 | fullnameOverride | string | `""` | Defaults to .Release.Name-.Chart.Name unless .Release.Name contains "pyroscope" |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"pyroscope/pyroscope"` | image to use for deploying |
-| image.tag | string | `"0.0.34"` | Tag for pyroscope image to use |
+| image.tag | string | `"0.0.37"` | Tag for pyroscope image to use |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | ingress.annotations | object | `{}` | Ingress annotations (values are templated) |
 | ingress.apiVersion | string | `"networking.k8s.io/v1"` | Ingress API version: networking.k8s.io/v1 (Kubernetes v1.19+) or networking.k8s.io/v1beta1 |
@@ -79,7 +88,7 @@ podSecurityContext:
 | persistence.size | string | `"10Gi"` | Size of persistent volume claim |
 | podAnnotations | object | `{}` | Pod annotations |
 | podSecurityContext | object | `{}` | Pod securityContext |
-| pyroscopeConfigs | object | `{"analytics-opt-out":"false","api-bind-addr":":4040","badger-log-level":"error","base-url":"","cache-dictionary-size":"1000","cache-dimension-size":"1000","cache-segment-size":"1000","cache-tree-size":"10000","log-level":"info","max-nodes-render":"2048","max-nodes-serialization":"2048","storage-path":"/var/lib/pyroscope"}` | Map of pyroscope configs to be used for ref default: https://pyroscope.io/docs/configuration#self-documented-server-config |
+| pyroscopeConfigs | object | `{}` | Pyroscope server configuration. Please refer to https://pyroscope.io/docs/server-configuration |
 | readinessProbe.enabled | bool | `true` | Enable Pyroscope server readiness |
 | readinessProbe.failureThreshold | int | `3` | Pyroscope server readiness check failure threshold count |
 | readinessProbe.httpGet.path | string | `"/healthz"` | Pyroscope server readiness check path |

--- a/chart/pyroscope/README.md.gotmpl
+++ b/chart/pyroscope/README.md.gotmpl
@@ -42,7 +42,8 @@ helm delete my-release
 
 ## Persistence
 
-If you enable persistence, you should also configure the pod's security context `fsGroup`, to be able to write to the persistent volume. Set it to the group ID of the user running Pyroscope - `101` in the official Pyroscope container image.
+If you enable persistence, you should also configure the pod's security context `fsGroup`, to be able to write to the persistent volume.
+The official Pyroscope container image runs pyroscope server process with user ID `101`, setting `fsGroup` to this value should be sufficient in most cases:
 
 ```yaml
 persistence:
@@ -50,5 +51,13 @@ persistence:
 podSecurityContext:
   fsGroup: 101
 ```
+
+This includes all processes of the container to the supplemental group and makes kubelet to change the ownership of mounted volumes to this group (recursively; setgid bit is set).
+The only requirement for `fsGroup` is that it should be within the allowed range (e.g. defined by `SecurityContextConstraints`).
+
+## Pyroscope configuration
+
+`pyroscopeConfigs` parameter may include any supported pyroscope server configuration option.
+Please refer to [the documentation](https://pyroscope.io/docs/server-configuration) for details.
 
 {{ template "chart.valuesSection" . }}

--- a/chart/pyroscope/values.yaml
+++ b/chart/pyroscope/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Tag for pyroscope image to use
-  tag: "0.0.34"
+  tag: "0.0.37"
 
 # -- Image pull secrets
 imagePullSecrets: []
@@ -33,43 +33,8 @@ serviceAccount:
   # -- ServiceAccount annotations
   annotations: {}
 
-# -- Map of pyroscope configs to be used for ref default: https://pyroscope.io/docs/configuration#self-documented-server-config
-pyroscopeConfigs:
-  # disables analytics
-  analytics-opt-out: "false"
-
-  # log level: debug|info|warn|error
-  log-level: "info"
-
-  # log level: debug|info|warn|error
-  badger-log-level: "error"
-
-  # directory where pyroscope stores profiling data
-  storage-path: "/var/lib/pyroscope"
-
-  # port for the HTTP server used for data ingestion and web UI
-  api-bind-addr: ":4040"
-
-  # base URL for when the server is behind a reverse proxy with a different path
-  base-url: ""
-
-  # max number of elements in LRU cache for dimensions
-  cache-dimension-size: "1000"
-
-  # max number of elements in LRU cache for dictionaries
-  cache-dictionary-size: "1000"
-
-  # max number of elements in LRU cache for segments
-  cache-segment-size: "1000"
-
-  # max number of elements in LRU cache for trees
-  cache-tree-size: "10000"
-
-  # max number of nodes used when saving profiles to disk
-  max-nodes-serialization: "2048"
-
-  # max number of nodes used to display data on the frontend
-  max-nodes-render: "2048"
+# -- Pyroscope server configuration. Please refer to https://pyroscope.io/docs/server-configuration
+pyroscopeConfigs: {}
 
  ## Enable persistence using Persistent Volume Claims
  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
The PR is aimed to improve documentation:
 - We had some issues re persistence setup (e.g https://github.com/pyroscope-io/pyroscope/issues/350). Although the documentation is correct, in some corner cases it may lead astray. Therefore I clarified use of `podSecurityContext.fsGroup` parameter.
 - I believe, at this point it's better to omit default pyroscope configuration, as it's extended quite often and may confuse users.

Besides, pyroscope version has changed from `0.0.34` to `0.0.37`.
