### PR TITLE
tolerations and nodeSelector options to agent's daemonset

### DIFF
--- a/chart/pyroscope-ebpf/Chart.yaml
+++ b/chart/pyroscope-ebpf/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pyroscope-ebpf
 description: A Helm chart for Pyroscope eBPF
 type: application
-version: 0.1.18
+version: 0.1.19
 appVersion: "0.34.1"

--- a/chart/pyroscope-ebpf/README.md
+++ b/chart/pyroscope-ebpf/README.md
@@ -1,6 +1,6 @@
 # pyroscope-ebpf
 
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.34.1](https://img.shields.io/badge/AppVersion-0.34.1-informational?style=flat-square)
+![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.34.1](https://img.shields.io/badge/AppVersion-0.34.1-informational?style=flat-square)
 
 A Helm chart for Pyroscope eBPF
 

--- a/chart/pyroscope-ebpf/templates/daemonset.yaml
+++ b/chart/pyroscope-ebpf/templates/daemonset.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         {{- include "pyroscope-ebpf.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/pyroscope-ebpf/templates/daemonset.yaml
+++ b/chart/pyroscope-ebpf/templates/daemonset.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         {{- include "pyroscope-ebpf.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "pyroscope-ebpf.serviceAccountName" . }}
       containers:
         - name: pyroscope-agent


### PR DESCRIPTION
We deploy pyroscope ebpf agent to our application gameservers.  We need the agent daemonset to run on a specific gameserver pool with existing an taint, which means the daemonset in the chart must be configurable with `tolerations` and `nodeSelector` options.